### PR TITLE
adds boost library flag for libdvid build

### DIFF
--- a/libdvid-cpp/build.sh
+++ b/libdvid-cpp/build.sh
@@ -13,6 +13,7 @@ cmake ..\
         -DCMAKE_CXX_FLAGS=-I${PREFIX}/include \
         -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib" \
         -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath,${PREFIX}/lib -L${PREFIX}/lib" \
+        -DBoost_LIBRARY_DIR=${PREFIX}/lib \
         -DBoost_INCLUDE_DIR=${PREFIX}/include \
         -DPYTHON_EXECUTABLE=${PYTHON} \
         -DLIBDVID_WRAP_PYTHON=1 \


### PR DESCRIPTION
The libdvid build changed slightly causing the conda build not to work.  This commit fixes the issue.